### PR TITLE
When clicking on navigation items in the mobile sidebar, the sidebar does not close automatically and remains open, even after the navigation is triggered.

### DIFF
--- a/components/mobile-sidebar.tsx
+++ b/components/mobile-sidebar.tsx
@@ -2,18 +2,21 @@
 import { PanelRightClose } from 'lucide-react'
 import { Sheet, SheetContent, SheetTrigger } from '@/components/ui/sheet'
 import { Sidebar } from '@/components/sidebar'
+import { useState } from 'react'
 
-{
-  /* Button to trigger sidebar contents */
-}
 export const MobileSidebar = () => {
+  const [open, setOpen] = useState(false)
+
+  const openSidebar = () => setOpen(true)
+  const closeSidebar = () => setOpen(false)
+
   return (
-    <Sheet>
-      <SheetTrigger className="sm:hidden pr-4 text-primary">
+    <Sheet open={open} onOpenChange={setOpen}>
+      <SheetTrigger className="sm:hidden pr-4 text-primary" onClick={openSidebar}>
         <PanelRightClose className="h-6 w-6 hover:text-primary/50 duration-300" />
       </SheetTrigger>
       <SheetContent side="left" className="p-6 border-none w-80 bg-secondary">
-        <Sidebar />
+        <Sidebar closeSidebar={closeSidebar} />
       </SheetContent>
     </Sheet>
   )

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -6,9 +6,6 @@ import Image from 'next/image'
 import { ModeToggle } from '@/components/mode-toggle'
 import { Logo } from '@/components/logo'
 
-{
-  /* Sidebar links & title*/
-}
 const sidebarPages = [
   {
     link: '/',
@@ -50,14 +47,19 @@ const socials = [
     title: 'Discord'
   }
 ]
-export const Sidebar = () => {
+
+interface SidebarProps {
+  closeSidebar?: () => void
+}
+
+export const Sidebar = ({ closeSidebar }: SidebarProps) => {
   const session = useCurrentUser()
   const Logout = () => {
     signOut()
   }
   return (
     <div className="flex flex-col justify-between pl-2">
-      <Link href="/">
+      <Link href="/" onClick={closeSidebar}>
         <Logo />
       </Link>
       <div className="flex pt-4">
@@ -74,6 +76,7 @@ export const Sidebar = () => {
                 className={cn(
                   'group flex py-1.5 w-full justify-start font-light cursor-pointer'
                 )}
+                onClick={closeSidebar}
               >
                 <div className="flex w-full">
                   <p className="font-normal text-foreground/75">{page.title}</p>
@@ -90,6 +93,7 @@ export const Sidebar = () => {
                 className={cn(
                   'group flex w-full justify-start font-light cursor-pointer py-1.5'
                 )}
+                onClick={closeSidebar}
               >
                 <div className="flex w-full">
                   <p className="font-normal text-foreground/75">{page.title}</p>
@@ -101,7 +105,10 @@ export const Sidebar = () => {
             <Link
               href="/login"
               className="group flex py-2 w-full justify-start cursor-pointer rounded ml-2 font-bold text-xl"
-              onClick={Logout}
+              onClick={() => {
+                Logout()
+                closeSidebar && closeSidebar()
+              }}
             >
               Logout
             </Link>
@@ -109,6 +116,7 @@ export const Sidebar = () => {
             <Link
               href="/login"
               className="group flex pt-2 w-full justify-start font-light cursor-pointer"
+              onClick={closeSidebar}
             >
               <div className="flex w-full ml-2 pb-3">
                 <p className="font-semibold ">Sign Up</p>


### PR DESCRIPTION
### Issue Description:
When clicking on navigation items in the mobile sidebar, the sidebar does not close automatically and remains open, even after the navigation is triggered.

### Solution:
This pull request fixes the issue by introducing a closeSidebar function passed as a prop to the Sidebar component. This function ensures that the sidebar closes automatically when any navigation link is clicked.

### Changes Made:

Sidebar.tsx:

- Added a closeSidebar prop to the Sidebar component.
- Called closeSidebar in the onClick event of each Link to ensure the sidebar closes when a link is clicked.

MobileSidebar.tsx:

- Managed the open state of the Sheet component.
- Passed the closeSidebar function to the Sidebar component to trigger the sidebar close action when a link is clicked.

### Code Changes:

Sidebar.tsx

```typescript
// Add closeSidebar prop to Sidebar component
interface SidebarProps {
  closeSidebar?: () => void
}

// Call closeSidebar on each Link click
<Link
  key={page.link}
  href={page.link}
  className={cn('group flex py-1.5 w-full justify-start font-light cursor-pointer')}
  onClick={closeSidebar}
>
  <div className="flex w-full">
    <p className="font-normal text-foreground/75">{page.title}</p>
  </div>
</Link>
```

MobileSidebar.tsx

```typescript
// Manage Sheet component state
const [open, setOpen] = useState(false)

const openSidebar = () => setOpen(true)
const closeSidebar = () => setOpen(false)

// Pass closeSidebar function to Sidebar component
<Sheet open={open} onOpenChange={setOpen}>
  <SheetTrigger className="sm:hidden pr-4 text-primary" onClick={openSidebar}>
    <PanelRightClose className="h-6 w-6 hover:text-primary/50 duration-300" />
  </SheetTrigger>
  <SheetContent side="left" className="p-6 border-none w-80 bg-secondary">
    <Sidebar closeSidebar={closeSidebar} />
  </SheetContent>
</Sheet>
```

**These changes ensure the mobile sidebar closes automatically upon navigation, improving the user experience. Thank you for reviewing this pull request!**