### PR TITLE
Adding missing stripe webhooks to handle subscriptions

### DIFF
--- a/app/api/webhook/route.ts
+++ b/app/api/webhook/route.ts
@@ -72,7 +72,6 @@ export async function POST(req: Request) {
         stripeSubscriptionId: subscription.id
       },
       data: {
-        stripePriceId: subscription.items.data[0].price.id,
         stripeCurrentPeriodEnd: new Date(event.data.object.current_period_end * 1000)
       }
     })

--- a/app/api/webhook/route.ts
+++ b/app/api/webhook/route.ts
@@ -22,6 +22,7 @@ export async function POST(req: Request) {
 
   const session = event.data.object as Stripe.Checkout.Session
 
+  // checkout.session.completed is sent after the initial purchase of the subscription from the checkout page
   if (event.type === 'checkout.session.completed') {
     const subscription = await stripe.subscriptions.retrieve(
       session.subscription as string
@@ -41,6 +42,43 @@ export async function POST(req: Request) {
     })
   }
 
+  // invoice.payment_succeeded is sent on subscription renewals
+  if (event.type === "invoice.payment_succeeded") {
+    // note: sometimes the subscription we get back doesn't have the up to date current_period_end
+    // which is why we also need to listen for customer.subscription.updated
+    const subscription = await stripe.subscriptions.retrieve(
+      session.subscription as string
+    );
+
+    const subscriptionId = subscription.id;
+
+    await db.userSubscription.update({
+      where: {
+        stripeSubscriptionId: subscription.id
+      },
+      data: {
+        stripePriceId: subscription.items.data[0].price.id,
+        stripeCurrentPeriodEnd: new Date(subscription.current_period_end * 1000)
+      }
+    })
+  }
+
+  // customer.subscription.updated is fired when their subscription end date changes
+  if (event.type === 'customer.subscription.updated') {
+    const subscriptionId = event.data.object.id as string;
+
+    await db.userSubscription.update({
+      where: {
+        stripeSubscriptionId: subscription.id
+      },
+      data: {
+        stripePriceId: subscription.items.data[0].price.id,
+        stripeCurrentPeriodEnd: new Date(event.data.object.current_period_end * 1000)
+      }
+    })
+  }
+
+  // invoice.payment_failed if the renewal fails
   if (event.type === 'invoice.payment_failed') {
     const subscription = await stripe.subscriptions.retrieve(
       session.subscription as string

--- a/app/api/webhook/route.ts
+++ b/app/api/webhook/route.ts
@@ -50,8 +50,6 @@ export async function POST(req: Request) {
       session.subscription as string
     );
 
-    const subscriptionId = subscription.id;
-
     await db.userSubscription.update({
       where: {
         stripeSubscriptionId: subscription.id
@@ -69,7 +67,7 @@ export async function POST(req: Request) {
 
     await db.userSubscription.update({
       where: {
-        stripeSubscriptionId: subscription.id
+        stripeSubscriptionId: subscriptionId
       },
       data: {
         stripeCurrentPeriodEnd: new Date(event.data.object.current_period_end * 1000)


### PR DESCRIPTION
I noticed your starter kit was missing two events that I've found necessary to have on my projectplannerai project:

- invoice.payment_succeeded - this is sent after the initial payment but also future months when the subscription is renewed.  checkout.session.completed is only called once after they first subscribe, so we can't depend on the subscription_end_date on just that event
- customer.subscription.updated - this is called after stripe successfully updates the subscription object's subscription_end_date.  The reason we want to listen for this is because the event has the latest version of the subscription in the event, so we can trust the end_date more so than invoice.payment_succeeded because sometimes when we fetch the subscription it'll have old data until it updates in the stripe database.

be sure to double check my logic


honestly, now that I look into other project examples, I think just listening for subscription.created / updated / deleted might be enough: https://github.com/vercel/nextjs-subscription-payments/blob/main/app/api/webhooks/route.ts