### PR TITLE
Fix Slider gradient in dark mode

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -37,7 +37,7 @@
   }
 
   .dark {
-    --background: 0 0% 7%;
+    --background:  249 11% 12%;
     --background-hover: 0 0% 13%;
     --foreground: 0 0% 98%;
     --card: 240 10% 3.9%;

--- a/app/globals.css
+++ b/app/globals.css
@@ -3,6 +3,11 @@
 @tailwind utilities;
 
 @layer base {
+  html,
+  body {
+    @apply bg-background;
+  }
+
   :root {
     /* Adjust these to change the theme's color */
     --primary: 234 88% 74%;
@@ -37,7 +42,7 @@
   }
 
   .dark {
-    --background:  249 11% 12%;
+    --background: 249 11% 12%;
     --background-hover: 0 0% 13%;
     --foreground: 0 0% 98%;
     --card: 240 10% 3.9%;

--- a/components/languages.tsx
+++ b/components/languages.tsx
@@ -28,7 +28,7 @@ const languages = [
 export function Language() {
   return (
     <section className="relative">
-      <div className="absolute top-0 left-0 w-1/4 h-full bg-gradient-to-r from-background pointer-events-none z-10"></div>
+      <div className="absolute top-0 left-0 w-1/4 h-full bg-gradient-to-r from-background to-transparent pointer-events-none z-10"></div>
       <div className="absolute top-0 right-0 w-1/4 h-full bg-gradient-to-r from-transparent to-background pointer-events-none z-10"></div>
       <Marquee speed={30} autoFill>
         {languages.map((language, i) => (

--- a/components/languages.tsx
+++ b/components/languages.tsx
@@ -28,7 +28,7 @@ const languages = [
 export function Language() {
   return (
     <section className="relative">
-      <div className="absolute top-0 left-0 w-1/4 h-full bg-gradient-to-r from-background to-transparent pointer-events-none z-10"></div>
+      <div className="absolute top-0 left-0 w-1/4 h-full bg-gradient-to-r from-background pointer-events-none z-10"></div>
       <div className="absolute top-0 right-0 w-1/4 h-full bg-gradient-to-r from-transparent to-background pointer-events-none z-10"></div>
       <Marquee speed={30} autoFill>
         {languages.map((language, i) => (


### PR DESCRIPTION
Currently the sliders gradient looks inconsistent on the dark mode version due to the hsl color of the background being black instead of the gray used in the actual background, I have fixed that in this commit!

Before: 

![image](https://github.com/user-attachments/assets/9d0ebfc9-0b1b-430d-b532-1e6c17912f08)

After:

![image](https://github.com/user-attachments/assets/f64674b2-dd91-442a-af90-f6b69216010d)
